### PR TITLE
[Feat/#5] 메인 페이지 api 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,8 @@ import { UserModule } from './user/user.module';
 import { User } from './user/entities/user.entity';
 import { PostModule } from './post/post.module';
 import { Post } from './post/entities/post.entity';
+import { ScheduleModule } from './schedule/schedule.module';
+import { Schedule } from './schedule/entities/schedule.entity';
 
 @Module({
   imports: [
@@ -20,11 +22,12 @@ import { Post } from './post/entities/post.entity';
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
-      entities: [User, Post],
+      entities: [User, Post, Schedule],
       synchronize: false,
     }),
     UserModule,
     PostModule,
+    ScheduleModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 import { UserModule } from './user/user.module';
 import { User } from './user/entities/user.entity';
+import { PostModule } from './post/post.module';
+import { Post } from './post/entities/post.entity';
 
 @Module({
   imports: [
@@ -18,10 +20,11 @@ import { User } from './user/entities/user.entity';
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
-      entities: [User],
+      entities: [User, Post],
       synchronize: false,
     }),
     UserModule,
+    PostModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/post/dto/post.dto.ts
+++ b/src/post/dto/post.dto.ts
@@ -1,0 +1,21 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class PostDto {
+  @IsNotEmpty()
+  contents: string;
+
+  thumbnail: string;
+
+  images: string[];
+
+  @IsNotEmpty()
+  created: Date;
+
+  @IsNotEmpty()
+  updated: Date;
+
+  @IsNotEmpty()
+  writer: number;
+
+  related_schedule: number[];
+}

--- a/src/post/entities/post.entity.ts
+++ b/src/post/entities/post.entity.ts
@@ -1,0 +1,28 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Post {
+  @PrimaryGeneratedColumn()
+  post_id: number;
+
+  @Column()
+  contents: string;
+
+  @Column()
+  thumbnail: string;
+
+  @Column({ array: true })
+  images: string;
+
+  @Column()
+  created: Date;
+
+  @Column()
+  updated: Date;
+
+  @Column()
+  writer: number;
+
+  @Column({ array: true })
+  related_schedule: number;
+}

--- a/src/post/post.controller.spec.ts
+++ b/src/post/post.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostController } from './post.controller';
+
+describe('PostController', () => {
+  let controller: PostController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PostController],
+    }).compile();
+
+    controller = module.get<PostController>(PostController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { PostService } from './post.service';
+
+@Controller('post')
+export class PostController {
+  constructor(private readonly postService: PostService) {}
+
+  @Get()
+  getPosts(@Query('cnt') cnt: number) {
+    return this.postService.getPosts(cnt);
+  }
+}

--- a/src/post/post.module.ts
+++ b/src/post/post.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PostController } from './post.controller';
+import { PostService } from './post.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Post } from './entities/post.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Post])],
+  controllers: [PostController],
+  providers: [PostService],
+})
+export class PostModule {}

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostService } from './post.service';
+
+describe('PostService', () => {
+  let service: PostService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PostService],
+    }).compile();
+
+    service = module.get<PostService>(PostService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -1,0 +1,31 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Post } from './entities/post.entity';
+
+@Injectable()
+export class PostService {
+  constructor(
+    @InjectRepository(Post) private readonly postRepository: Repository<Post>,
+  ) {}
+
+  async getPosts(cnt: number): Promise<Post[]> {
+    let posts;
+    if (!cnt) {
+      posts = await this.postRepository.find({
+        order: {
+          updated: 'DESC',
+        },
+      });
+    } else
+      posts = await this.postRepository.find({
+        order: {
+          updated: 'DESC',
+        },
+        take: cnt,
+      });
+    if (!posts)
+      throw new HttpException('게시글이 없습니다', HttpStatus.BAD_REQUEST);
+    return posts;
+  }
+}

--- a/src/schedule/dto/schedule.dto.ts
+++ b/src/schedule/dto/schedule.dto.ts
@@ -1,0 +1,33 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class ScheduleDto {
+  @IsNotEmpty()
+  schedule_type: number;
+
+  @IsNotEmpty()
+  title: string;
+
+  @IsNotEmpty()
+  place: string;
+
+  @IsNotEmpty()
+  duration: string;
+
+  @IsNotEmpty()
+  meet_place: string;
+
+  @IsNotEmpty()
+  meet_time: Date;
+
+  @IsNotEmpty()
+  participants: number[];
+
+  @IsNotEmpty()
+  created: Date;
+
+  @IsNotEmpty()
+  updated: Date;
+
+  @IsNotEmpty()
+  scheduler: number;
+}

--- a/src/schedule/entities/schedule.entity.ts
+++ b/src/schedule/entities/schedule.entity.ts
@@ -1,0 +1,37 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Schedule {
+  @PrimaryGeneratedColumn()
+  schedule_id: number;
+
+  @Column()
+  schedule_type: number;
+
+  @Column()
+  title: string;
+
+  @Column()
+  place: string;
+
+  @Column()
+  duration: string;
+
+  @Column()
+  meet_place: string;
+
+  @Column()
+  meet_time: Date;
+
+  @Column({ array: true })
+  participants: number;
+
+  @Column()
+  created: Date;
+
+  @Column()
+  updated: Date;
+
+  @Column()
+  scheduler: number;
+}

--- a/src/schedule/schedule.controller.spec.ts
+++ b/src/schedule/schedule.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ScheduleController } from './schedule.controller';
+
+describe('ScheduleController', () => {
+  let controller: ScheduleController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ScheduleController],
+    }).compile();
+
+    controller = module.get<ScheduleController>(ScheduleController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/schedule/schedule.controller.ts
+++ b/src/schedule/schedule.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ScheduleService } from './schedule.service';
+
+@Controller('schedule')
+export class ScheduleController {
+  constructor(private readonly scheduleService: ScheduleService) {}
+
+  @Get()
+  getSchedules(@Query('cnt') cnt: number) {
+    return this.scheduleService.getSchedules(cnt);
+  }
+}

--- a/src/schedule/schedule.module.ts
+++ b/src/schedule/schedule.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ScheduleController } from './schedule.controller';
+import { ScheduleService } from './schedule.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Schedule } from './entities/schedule.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Schedule])],
+  controllers: [ScheduleController],
+  providers: [ScheduleService],
+})
+export class ScheduleModule {}

--- a/src/schedule/schedule.service.spec.ts
+++ b/src/schedule/schedule.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ScheduleService } from './schedule.service';
+
+describe('ScheduleService', () => {
+  let service: ScheduleService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ScheduleService],
+    }).compile();
+
+    service = module.get<ScheduleService>(ScheduleService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/schedule/schedule.service.ts
+++ b/src/schedule/schedule.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { Schedule } from './entities/schedule.entity';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class ScheduleService {
+  constructor(
+    @InjectRepository(Schedule)
+    private readonly scheduleRepository: Repository<Schedule>,
+  ) {}
+
+  async getSchedules(cnt: number): Promise<Schedule[]> {
+    let schedules;
+    if (!cnt) {
+      schedules = await this.scheduleRepository.find({
+        order: {
+          updated: 'DESC',
+        },
+      });
+    } else
+      schedules = await this.scheduleRepository.find({
+        order: {
+          updated: 'DESC',
+        },
+        take: cnt,
+      });
+    if (!schedules)
+      throw new HttpException('스케줄이 없습니다', HttpStatus.BAD_REQUEST);
+    return schedules;
+  }
+}


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->
- 게시글 특정 수만큼 조회 구현
- 스케줄 특정 수만큼 조회 구현

## 🥥 Contents
<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->
### 게시글 특정 수만큼 조회
```ts
// Service
async getPosts(cnt: number): Promise<Post[]> {
    let posts;
    if (!cnt) { ... // cnt == 0 -> 게시글 전체 조회 } 
    else ... // cnt > 0 -> 특정 수만큼만 조회
    if (!posts)
      throw new HttpException('게시글이 없습니다', HttpStatus.BAD_REQUEST);
    return posts;
  }

// Controller
@Get()
getPosts(@Query('cnt') cnt: number) {
  return this.postService.getPosts(cnt);
}
```
- request parameter 로 받는 cnt 를 controller 가 받아 service 로 넘겨줌
- cnt 가 0 이냐 아니냐에 따라 다른 처리 필요
- 만약 조회한 게시글이 없다면 exception 을, 있다면 게시글을 반환
<br>

### 스케줄 특정 수만큼 조회
```ts
// Service
async getSchedules(cnt: number): Promise<Schedule[]> {
    let schedules;
    if (!cnt) { ... // cnt == 0 -> 스케줄 전체 조회 } 
    else ... // cnt > 0 -> 특정 수만큼만 조회
    if (!schedules)
      throw new HttpException('스케줄이 없습니다', HttpStatus.BAD_REQUEST);
    return schedules;
  }

// Controller
@Get()
getSchedules(@Query('cnt') cnt: number) {
  return this.scheduleService.getSchedules(cnt);
}
```
- request parameter 로 받는 cnt 를 controller 가 받아 service 로 넘겨줌
- cnt 가 0 이냐 아니냐에 따라 다른 처리 필요
- 만약 조회한 스케줄이 없다면 exception 을, 있다면 스케줄을 반환

## 🧪 Testing
<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->
- [x] 게시글 조회 확인( cnt 에 따라 다른 조회 )
- [x] 스케줄 조회 확인( cnt 에 따라 다른 조회 )

## ⚓ Related Issue
- #5 

close #5
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference
<!-- 자신이 참조한 정보의 출처를 적는다. -->
