### PR TITLE
[Feat/#11] 이메일 비밀번호 찾기 구현

### DIFF
--- a/src/user/dto/user.password.dto.ts
+++ b/src/user/dto/user.password.dto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class UserPasswordDto {
+  @IsNotEmpty()
+  email: string;
+
+  @IsNotEmpty()
+  name: string;
+
+  @IsNotEmpty()
+  phone: string;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import { Controller, Post, Get, Body, Res, Param } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserLoginDto } from './dto/user.login.dto';
 import { Response } from 'express';
@@ -38,5 +38,13 @@ export class UserController {
       maxAge: 0,
     });
     return res.send(true);
+  }
+
+  @Get('/find/email')
+  async findEmail(
+    @Param('name') name: string,
+    @Param('phone') phone: string,
+  ): Promise<string | boolean> {
+    return await this.userService.findEmail(name, phone);
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -3,6 +3,7 @@ import { UserService } from './user.service';
 import { UserLoginDto } from './dto/user.login.dto';
 import { Response } from 'express';
 import { ConfigService } from '@nestjs/config';
+import { UserPasswordDto } from './dto/user.password.dto';
 
 @Controller('user')
 export class UserController {
@@ -46,5 +47,12 @@ export class UserController {
     @Param('phone') phone: string,
   ): Promise<string | boolean> {
     return await this.userService.findEmail(name, phone);
+  }
+
+  @Post('/find/password')
+  async findPassword(
+    @Body() userPasswordDto: UserPasswordDto,
+  ): Promise<boolean> {
+    return await this.userService.findPassword(userPasswordDto);
   }
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -29,4 +29,12 @@ export class UserRepository extends Repository<User> {
     const duplicate = await this.findOneBy({ nickname });
     return !duplicate;
   }
+
+  async findEmailByNameAndPhone(
+    name: string,
+    phone: string,
+  ): Promise<string | boolean> {
+    const targetEmail = await this.findOneBy({ name, phone });
+    return !targetEmail.email ? false : targetEmail.email;
+  }
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -3,10 +3,16 @@ import { User } from './entities/user.entity';
 import { Injectable } from '@nestjs/common';
 import { UserDto } from './dto/user.dto';
 import { UserLoginResponseDto } from './dto/user.login.response.dto';
+import { UserPasswordDto } from './dto/user.password.dto';
+import * as bcrypt from 'bcrypt';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class UserRepository extends Repository<User> {
-  constructor(private dataSource: DataSource) {
+  constructor(
+    private dataSource: DataSource,
+    private configService: ConfigService,
+  ) {
     super(User, dataSource.createEntityManager());
   }
 
@@ -36,5 +42,26 @@ export class UserRepository extends Repository<User> {
   ): Promise<string | boolean> {
     const targetEmail = await this.findOneBy({ name, phone });
     return !targetEmail.email ? false : targetEmail.email;
+  }
+
+  async findUserByEmailAndNameAndPhone(
+    userPasswordDto: UserPasswordDto,
+  ): Promise<UserDto> {
+    return await this.findOneBy({
+      email: userPasswordDto.email,
+      name: userPasswordDto.name,
+      phone: userPasswordDto.phone,
+    });
+  }
+
+  async changePasswordToTemp(
+    user: UserDto,
+    tmpPassword: string,
+  ): Promise<void> {
+    user.password = await bcrypt.hash(
+      tmpPassword,
+      Number(this.configService.get('BCRYPT_HASH_KEY')),
+    );
+    await this.save(user);
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -51,4 +51,8 @@ export class UserService {
       }
     }
   }
+
+  async findEmail(name: string, phone: string): Promise<string | boolean> {
+    return await this.userRepository.findEmailByNameAndPhone(name, phone);
+  }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -5,14 +5,29 @@ import { UserLoginDto } from './dto/user.login.dto';
 import { UserLoginResponseDto } from './dto/user.login.response.dto';
 import * as bcrypt from 'bcrypt';
 import { AuthService } from 'src/auth/auth.service';
+import { UserPasswordDto } from './dto/user.password.dto';
+import Mail = require('nodemailer/lib/mailer');
+import * as nodemailer from 'nodemailer';
+import { ConfigService } from '@nestjs/config';
+import { EmailOptions } from 'src/signup/interface/emailoption.interface';
 
 @Injectable()
 export class UserService {
+  private transporter: Mail;
   constructor(
     @InjectRepository(UserRepository)
     private userRepository: UserRepository,
     private authService: AuthService,
-  ) {}
+    private configService: ConfigService,
+  ) {
+    this.transporter = nodemailer.createTransport({
+      service: 'Gmail',
+      auth: {
+        user: this.configService.get('EMAIL_USER'),
+        pass: this.configService.get('EMAIL_PASSWORD'),
+      },
+    });
+  }
 
   async findUser(userLoginDto: UserLoginDto): Promise<{
     user: UserLoginResponseDto;
@@ -54,5 +69,29 @@ export class UserService {
 
   async findEmail(name: string, phone: string): Promise<string | boolean> {
     return await this.userRepository.findEmailByNameAndPhone(name, phone);
+  }
+
+  async findPassword(userPasswordDto: UserPasswordDto): Promise<boolean> {
+    const user =
+      await this.userRepository.findUserByEmailAndNameAndPhone(userPasswordDto);
+    if (!user) {
+      throw new HttpException(
+        '등록되지 않은 사용자입니다!!',
+        HttpStatus.BAD_REQUEST,
+      );
+    } else {
+      const tmpPassword = Math.random().toString(36).slice(2);
+      const mailOptions: EmailOptions = {
+        to: user.email,
+        subject: '임시 비밀번호 발급',
+        html: `임시 비밀번호: ${tmpPassword}`,
+      };
+      const sendResult = await this.transporter.sendMail(mailOptions);
+      console.log(sendResult);
+      if (sendResult.accepted.includes(user.email)) {
+        await this.userRepository.changePasswordToTemp(user, tmpPassword);
+        return true;
+      } else return false;
+    }
   }
 }


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목
[<이슈 종류>/<이슈번호1>, <이슈번호2>] <제목>
-->

<!-- 리뷰어랑 담당자, 라벨 설정했는지 확인하세요 -->

## 🚀 Background
<!-- 어떤 걸 고치고 pr을 했는지 간단하게 -->
- 이메일 찾기 구현
- 비밀번호 찾기 구현

## 🥥 Contents
<!--
코드, 개발 관점에서 어떤걸 고쳤는지 상세하게
사진같은걸 넣어도 된다.
pr 보는 사람이 따로 정보를 안 찾아봐도 되게 적는게 이상적
-->
### 이메일 찾기
- 이름과 전화번호를 통해 존재하는 유저인지 확인 필요
- 존재하는 유저라면 이메일 반환
<br>

### 비밀번호 찾기
- 이름+전화번호에 이메일까지 함께 받아서 존재하는 유저인지 확인 필요
- 존재하는 유저라면 임시 비밀번호 생성하여 이메일로 전송
- true 를 반환하여 이메일이 전송되었음을 알려줌

## 🧪 Testing
<!-- 테스트 방법이나, 테스트 한 목록들을 적는다. -->
- [x] 이메일 반환 확인
- [x] 임시 비밀번호 메일 전송 확인

## ⚓ Related Issue
- #11 

close #11
<!-- 이슈 번호를 적어주면 되고, close 같은 자동 닫힘을 등록하여도 된다. -->

## 📚 Reference
<!-- 자신이 참조한 정보의 출처를 적는다. -->
